### PR TITLE
RDKB-63015:  Fix to support repo without autogen script

### DIFF
--- a/cov_docker_script/build_native.sh
+++ b/cov_docker_script/build_native.sh
@@ -240,6 +240,16 @@ build_component_autotools() {
         fi
         ok "autogen.sh completed"
         echo ""
+    elif [[ ! -f "./configure" ]] && [[ -f "./configure.ac" ]]; then
+        # No autogen.sh and no configure, but configure.ac exists
+        # Run autoreconf to generate configure script
+        step "Running autoreconf to generate configure script"
+        if ! autoreconf -fi; then
+            err "autoreconf failed"
+            return 1
+        fi
+        ok "autoreconf completed"
+        echo ""
     fi
     
     # Configure


### PR DESCRIPTION
Updating the build_native.sh to use autoreconf when autogen.sh is not available but configure.ac is available