### PR TITLE
CMF-14020 Add cleanup in auto_pr_generation_manifest script

### DIFF
--- a/.github/workflows/auto_pr_creation_rpi_manifests.yml
+++ b/.github/workflows/auto_pr_creation_rpi_manifests.yml
@@ -84,7 +84,7 @@ jobs:
           MANIFEST_REPO_PATH: ${{ github.workspace }}/vendor_manifest_repo
           MANIFEST_REPO_NAME: 'rdkcentral/vendor-manifest-raspberrypi'
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_BRANCH: develop
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
             cd vendor_manifest_repo
             python3 ../tools/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
@@ -97,7 +97,7 @@ jobs:
           MANIFEST_REPO_PATH: ${{ github.workspace }}/middleware_manifest_repo
           MANIFEST_REPO_NAME: 'rdkcentral/middleware-manifest-rdke'
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_BRANCH: develop
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
             cd middleware_manifest_repo
             python3 ../tools/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
@@ -110,7 +110,7 @@ jobs:
           MANIFEST_REPO_PATH: ${{ github.workspace }}/image_assembler_manifest_repo
           MANIFEST_REPO_NAME: 'rdkcentral/image-assembler-manifest-rdke'
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_BRANCH: develop
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
             cd image_assembler_manifest_repo
             python3 ../tools/build_health_check_workflow_scripts/auto_pr_generation_manifest.py

--- a/.github/workflows/auto_pr_creation_rpi_manifests.yml
+++ b/.github/workflows/auto_pr_creation_rpi_manifests.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           repository: rdkcentral/build_tools_workflows
           path: 'tools'
-          ref: develop
+          ref: feature/CMF-14020
           token: ${{ secrets.RDKCM_RDKE }}
 
       - name: Checkout vendor layer Manifest Repository

--- a/.github/workflows/auto_pr_creation_rpi_manifests.yml
+++ b/.github/workflows/auto_pr_creation_rpi_manifests.yml
@@ -84,7 +84,7 @@ jobs:
           MANIFEST_REPO_PATH: ${{ github.workspace }}/vendor_manifest_repo
           MANIFEST_REPO_NAME: 'rdkcentral/vendor-manifest-raspberrypi'
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          BASE_BRANCH: develop
         run: |
             cd vendor_manifest_repo
             python3 ../tools/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
@@ -97,7 +97,7 @@ jobs:
           MANIFEST_REPO_PATH: ${{ github.workspace }}/middleware_manifest_repo
           MANIFEST_REPO_NAME: 'rdkcentral/middleware-manifest-rdke'
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          BASE_BRANCH: develop
         run: |
             cd middleware_manifest_repo
             python3 ../tools/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
@@ -110,7 +110,7 @@ jobs:
           MANIFEST_REPO_PATH: ${{ github.workspace }}/image_assembler_manifest_repo
           MANIFEST_REPO_NAME: 'rdkcentral/image-assembler-manifest-rdke'
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          BASE_BRANCH: develop
         run: |
             cd image_assembler_manifest_repo
             python3 ../tools/build_health_check_workflow_scripts/auto_pr_generation_manifest.py

--- a/.github/workflows/auto_pr_creation_rpi_manifests.yml
+++ b/.github/workflows/auto_pr_creation_rpi_manifests.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           repository: rdkcentral/build_tools_workflows
           path: 'tools'
-          ref: feature/CMF-14020
+          ref: develop
           token: ${{ secrets.RDKCM_RDKE }}
 
       - name: Checkout vendor layer Manifest Repository

--- a/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
+++ b/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
@@ -255,7 +255,7 @@ def delete_branch(repo, branch_name):
     print(':{}'.format(branch_name))
     try:
         remote = repo.remote(name='origin')
-        remote.push(refspec=(':delete_me'))
+        remote.push(refspec=(':{}'.format(branch_name)))
     except GitCommandError as e:
         print("Error delete branch: {}".format(str(e)))
         sys.exit(1)

--- a/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
+++ b/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
@@ -204,7 +204,7 @@ def create_pull_request(github_token, repo_name, head_branch, base_branch, title
 
     try:
         pr = repo.create_pull(title=title, body=description, base=base_branch, head=head_branch)
-        pr.add_to_labels('bhc-auto-merge')
+#        pr.add_to_labels('bhc-auto-merge')
         print("PR Created and labeled:", pr.html_url)
         return pr
     except github.GithubException as e:

--- a/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
+++ b/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
@@ -251,11 +251,11 @@ def create_or_checkout_branch(repo, branch_name, base_branch):
 
 # Delete the unused branch in the remote manifest repository
 def delete_branch(repo, branch_name):
-    print("Delete unsed branch: {}".format(branch_name))
+    print("Delete unused branch: {}".format(branch_name))
     print(':{}'.format(branch_name))
     try:
         remote = repo.remote(name='origin')
-#        remote.push(refspec=(':delete_me'))
+        remote.push(refspec=(':delete_me'))
     except GitCommandError as e:
         print("Error delete branch: {}".format(str(e)))
         sys.exit(1)

--- a/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
+++ b/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
@@ -249,6 +249,17 @@ def create_or_checkout_branch(repo, branch_name, base_branch):
         print("Error checking out branch: {}".format(str(e)))
         sys.exit(1)
 
+# Delete the unused branch in the remote manifest repository
+def delete_branch(repo, branch_name):
+    print("Delete unsed branch: {}".format(branch_name))
+    print(':{}'.format(branch_name))
+    try:
+        remote = repo.remote(name='origin')
+#        remote.push(refspec=(':delete_me'))
+    except GitCommandError as e:
+        print("Error delete branch: {}".format(str(e)))
+        sys.exit(1)
+
 def main():
     github_token = os.getenv('GITHUB_TOKEN')
     manifest_repo_path = os.getenv('MANIFEST_REPO_PATH')
@@ -290,8 +301,12 @@ def main():
     
     changes_made = update_xml_files(manifest_repo_path, updates)
     if changes_made:  
-      commit_and_push(manifest_repo_path, "Update manifest for {}".format(','.join(updates.keys())))
-      create_pull_request(github_token, manifest_repo_name, feature_branch, base_branch, manifest_pr_title, manifest_pr_description)
+        commit_and_push(manifest_repo_path, "Update manifest for {}".format(','.join(updates.keys())))
+        create_pull_request(github_token, manifest_repo_name, feature_branch, base_branch, manifest_pr_title, manifest_pr_description)
+    else:
+        # delete the unused feature branch
+        delete_branch(repo, feature_branch)
+
 
 if __name__ == '__main__':
     main()

--- a/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
+++ b/build_health_check_workflow_scripts/auto_pr_generation_manifest.py
@@ -204,7 +204,7 @@ def create_pull_request(github_token, repo_name, head_branch, base_branch, title
 
     try:
         pr = repo.create_pull(title=title, body=description, base=base_branch, head=head_branch)
-#        pr.add_to_labels('bhc-auto-merge')
+        pr.add_to_labels('bhc-auto-merge')
         print("PR Created and labeled:", pr.html_url)
         return pr
     except github.GithubException as e:


### PR DESCRIPTION
auto_pr_generation_manifest script does not clean up feature branch if there is no manifest update, this could lead to leaving branches in repos that have no purpose.

Add a cleanup action to delete these unused branches.