### PR TITLE
RDKB-64491: Prevent Duplicate Dependency components Builds in Native build tools

### DIFF
--- a/cov_docker_script/common_build_utils.sh
+++ b/cov_docker_script/common_build_utils.sh
@@ -40,6 +40,16 @@ check_dependencies() {
     return 0
 }
 
+# Get latest commit id
+get_latest_sha() {
+    local repo_path="$1"
+
+    git -C "$repo_path" rev-parse -is-inside-work-tree >/dev/null 2>&1 \
+        || { echo "Invalid git repo"; return 1; }
+
+    git -C "$repo_path" rev-parse --short HEAD
+}
+
 # Clone a git repository
 clone_repo() {
     local name="$1" repo="$2" branch="$3" dest="$4"

--- a/cov_docker_script/setup_dependencies.sh
+++ b/cov_docker_script/setup_dependencies.sh
@@ -112,7 +112,7 @@ build_repository() {
         # Copy libraries
         copy_libraries "$repo_dir" "$USR_DIR/local/lib"
         copy_libraries "$repo_dir" "$USR_DIR/lib"
-        log "Build alredy done for SHA: $LATEST_SHA, skipping."
+        log "Build already done for SHA: $LATEST_SHA, skipping rebuild."
         return 0
     fi
     

--- a/cov_docker_script/setup_dependencies.sh
+++ b/cov_docker_script/setup_dependencies.sh
@@ -39,7 +39,13 @@ initialize_environment() {
         [[ -d "$BUILD_DIR" ]] && rm -rf "$BUILD_DIR"
         [[ -d "$USR_DIR" ]] && rm -rf "$USR_DIR"
     fi
-    
+
+    # Rebuild if requested
+    if [[ "${RE_BUILD:-false}" == "true" ]]; then
+        warn "Removing previous build completed flags"
+        [[ -d "$BUILD_DIR" ]] && find "$BUILD_DIR" -type f -name 'build_*.done' -print -delete
+    fi
+
     # Create directories
     mkdir -p "$BUILD_DIR"
     mkdir -p "$USR_DIR/include/rdkb"
@@ -98,6 +104,15 @@ build_repository() {
     
     if [[ -z "$build_type" ]]; then
         log "No build configuration for $name (headers only)"
+        return 0
+    fi
+
+    local LATEST_SHA="$(get_latest_sha "$repo_dir")"
+    if [ -f "$repo_dir/build_${LATEST_SHA}.done" ]; then
+        # Copy libraries
+        copy_libraries "$repo_dir" "$USR_DIR/local/lib"
+        copy_libraries "$repo_dir" "$USR_DIR/lib"
+        log "Build alredy done for SHA: $LATEST_SHA, skipping."
         return 0
     fi
     
@@ -174,6 +189,7 @@ build_repository() {
     copy_libraries "$repo_dir" "$USR_DIR/lib"
     
     ok "$name build completed"
+    touch "$repo_dir/build_${LATEST_SHA}.done"
     return 0
 }
 


### PR DESCRIPTION
Reason for change: Preventing unnecessary rebuilds to improve build efficiency.
Test Procedure: Components native should pass
Risks: Low
Priority: P1
Signed-off-by: Netaji Panigrahi Netaji_Panigrahi@comcast.com