### PR TITLE
fix: update actions/checkout from v4 to v5 in fossid workflow (main)

### DIFF
--- a/.github/workflows/fossid_integration_stateless_diffscan.yml
+++ b/.github/workflows/fossid_integration_stateless_diffscan.yml
@@ -13,25 +13,36 @@ on:
         required: true
 
 jobs:
-  run-fossid-cicd:
+  run-diffscan:
     name: Fossid Annotate PR
     runs-on: ubuntu-latest
     container:
-      image: quay.io/fossid/fossid-cicd:0.2.15
+      image: quay.io/fossid/fossid-toolbox:1.5.29
       credentials:
-        username:  ${{ secrets.FOSSID_CONTAINER_USERNAME }}
-        password: '${{ secrets.FOSSID_CONTAINER_PASSWORD }}'
+        username: ${{ secrets.FOSSID_CONTAINER_USERNAME }}
+        password: ${{ secrets.FOSSID_CONTAINER_PASSWORD }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Run fossid-cicd
+      - name: Checkout Code
+        uses: actions/checkout@v5
+
+      - name: Checkout ignore projects file
+        uses: actions/checkout@v5
+        with:
+          repository: rdkcentral/build_tools_workflows
+          sparse-checkout: |
+            ignore_projects_fossid
+          ref: develop
+          path: tools
+
+      - name: Run fossid-toolbox
         env:
           FOSSID_HOST_USERNAME: ${{ secrets.FOSSID_HOST_USERNAME }}
           FOSSID_HOST_TOKEN: ${{ secrets.FOSSID_HOST_TOKEN }}
         run: |
-          fossid-cicd \
-          diff-scan \
-          --fossid-host $FOSSID_HOST_USERNAME \
-          --fossid-token $FOSSID_HOST_TOKEN \
-          --github-workflow-errors \
-          --fail-on-any-issues 1
+          fossid \
+            diffscan \
+            --fossid-host $FOSSID_HOST_USERNAME \
+            --fossid-token $FOSSID_HOST_TOKEN \
+            --format github \
+            --fail \
+            --ignore-projects tools/ignore_projects_fossid


### PR DESCRIPTION
Follow-up to PR #40 (develop). Applies equivalent checkout v5 hotfix to main.