### PR TITLE
fix(release): update FossID workflow checkouts to actions/checkout@v5

### DIFF
--- a/.github/workflows/fossid_integration_stateless_diffscan.yml
+++ b/.github/workflows/fossid_integration_stateless_diffscan.yml
@@ -23,17 +23,17 @@ jobs:
         password: ${{ secrets.FOSSID_CONTAINER_PASSWORD }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
-        
+        uses: actions/checkout@v5
+
       - name: Checkout ignore projects file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: rdkcentral/build_tools_workflows
           sparse-checkout: |
             ignore_projects_fossid
           ref: 1.0.0
           path: tools
-        
+
       - name: Run fossid-toolbox
         env:
           FOSSID_HOST_USERNAME: ${{ secrets.FOSSID_HOST_USERNAME }}


### PR DESCRIPTION
### Summary
This PR updates the release-branch FossID workflow to use `actions/checkout@v5`.

### Changes made
- Updated checkout action from `actions/checkout@v4` to `actions/checkout@v5` in `.github/workflows/fossid_integration_stateless_diffscan.yml`.
- Preserved release behavior by keeping `ref: 1.0.0` unchanged.

### Why this change
- Align with the checkout v5 update already merged on develop.
- Apply only the checkout version upgrade on the release line without changing release ref targeting.

### Scope and risk
- Narrow scope: single workflow file, checkout-version-only change.
- No changes to `FossID` command behaviors or release/tag wiring beyond checkout action version.

### Validation
- Cherry-pick from `develop` applied on a release-based branch.
- Verified workflow still references `ref: 1.0.0`.
- Verified both checkout steps now use `actions/checkout@v5`.