### PR TITLE
Update FossID workflow to use actions/checkout@v5

### DIFF
--- a/.github/workflows/fossid_integration_stateless_diffscan.yml
+++ b/.github/workflows/fossid_integration_stateless_diffscan.yml
@@ -13,25 +13,36 @@ on:
         required: true
 
 jobs:
-  run-fossid-cicd:
+  run-diffscan:
     name: Fossid Annotate PR
     runs-on: ubuntu-latest
     container:
-      image: quay.io/fossid/fossid-cicd:0.2.15
+      image: quay.io/fossid/fossid-toolbox:1.5.29
       credentials:
-        username:  ${{ secrets.FOSSID_CONTAINER_USERNAME }}
-        password: '${{ secrets.FOSSID_CONTAINER_PASSWORD }}'
+        username: ${{ secrets.FOSSID_CONTAINER_USERNAME }}
+        password: ${{ secrets.FOSSID_CONTAINER_PASSWORD }}
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v4
-      - name: Run fossid-cicd
+        
+      - name: Checkout ignore projects file
+        uses: actions/checkout@v4
+        with:
+          repository: rdkcentral/build_tools_workflows
+          sparse-checkout: |
+            ignore_projects_fossid
+          ref: 1.0.0
+          path: tools
+        
+      - name: Run fossid-toolbox
         env:
           FOSSID_HOST_USERNAME: ${{ secrets.FOSSID_HOST_USERNAME }}
           FOSSID_HOST_TOKEN: ${{ secrets.FOSSID_HOST_TOKEN }}
         run: |
-          fossid-cicd \
-          diff-scan \
-          --fossid-host $FOSSID_HOST_USERNAME \
-          --fossid-token $FOSSID_HOST_TOKEN \
-          --github-workflow-errors \
-          --fail-on-any-issues 1
+          fossid \
+            diffscan \
+            --fossid-host $FOSSID_HOST_USERNAME \
+            --fossid-token $FOSSID_HOST_TOKEN \
+            --format github \
+            --fail \
+            --ignore-projects tools/ignore_projects_fossid

--- a/.github/workflows/fossid_integration_stateless_diffscan.yml
+++ b/.github/workflows/fossid_integration_stateless_diffscan.yml
@@ -23,17 +23,17 @@ jobs:
         password: ${{ secrets.FOSSID_CONTAINER_PASSWORD }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
-        
+        uses: actions/checkout@v5
+
       - name: Checkout ignore projects file
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: rdkcentral/build_tools_workflows
           sparse-checkout: |
             ignore_projects_fossid
           ref: 1.0.0
           path: tools
-        
+
       - name: Run fossid-toolbox
         env:
           FOSSID_HOST_USERNAME: ${{ secrets.FOSSID_HOST_USERNAME }}

--- a/ignore_projects_fossid
+++ b/ignore_projects_fossid
@@ -1,0 +1,311 @@
+# GitHub wildcard ignores
+
+github.com/rdkcentral
+github.com/rdkcmf
+
+# rdk/components/generic/sys_mon_tools/udhcpc-opt43
+0312e061bbb8021780be869000000000
+# rdk/components/generic/sys_mon_tools/key_simulator
+032af61a6a50ee25f4c59eed00000000
+# rdkb/devices/emulator/hal
+0551aa5d79c9f0fe3aa5805100000000
+# rdkb/components/opensource/ccsp/halinterface
+0555a82bf76256a3c1baa9e800000000
+# rdk/components/generic/iarmmgrs
+0821ae7c2e1a9e045ca4342c00000000
+# rdk/components/generic/telemetry
+08e9bcaa60ec00deb15d646600000000
+# rdk/components/generic/sys_mon_tools/analyzers/scripts/host
+0ac07f8031ca4c1e870a603200000000
+# rdkb/devices/raspberrypi/sysint
+0cabe96eb3d3e0393933053b00000000
+# rdkb/devices/rdkbemu/rdkbemu_xb3
+0d1f929be7f59af3aaf2294600000000
+# rdk/components/generic/sys_mon_tools/hostdataconverter
+0df0e8ef62d978b9d48088b100000000
+# rdk/components/generic/libunpriv
+1394b999767a4105dccce04800000000
+# rdkb/components/opensource/ccsp/CcspCMAgent
+13e90f9271fab4b1284409a800000000
+# rdk/components/generic/aampabr
+14cc54766d46e356b31eada200000000
+# rdkb/devices/raspberrypi/hal
+17631c9e8be77d5839e8aeb800000000
+# rdk/components/opensource/oe/meta-python2
+1c232d52506c8c0111404a6b00000000
+# rdk/components/opensource/oe/meta-oic
+1efdd733d486afd3554a118e00000000
+# rdk/components/generic/aampmetrics
+1f2d6e54b3b673eb0baf8a5d00000000
+# rdkb/components/opensource/ccsp/CcspCommonLibrary
+21790ddde6bb474a47e5831d00000000
+# rdk/components/generic/sys_mon_tools/mem_analyser_tools
+21f792421a70ce360c6b247f00000000
+# rdk/components/generic/rdkbrowser2
+2209c733fb593254df10690f00000000
+# rdk/components/generic/sys_mon_tools/power-state-monitor
+233ab58215eda0a1606fa37600000000
+# rdk/components/generic/syslog_helper
+23f95bc5c142108a4f5f2e8b00000000
+# rdk/components/generic/gstreamer-direct-platform
+23fff951e1b7273399aeeec900000000
+# rdk/components/generic/sys_mon_tools/sys_utils
+24947b1d57b3bd66b1cfa88b00000000
+# rdk/components/generic/ledmgr
+26b79ff9e9b7f137dfde1ca700000000
+# rdk/devices/raspberrypi/webpa-client
+28a78bb9e71c2db403cdab3300000000
+# components/opensource/gdbus-client
+28b95cb76e9c4b3035c92e1000000000
+# rdkb/components/opensource/ccsp/CcspLMLite
+2b44713ff1ac1c670732f2a800000000
+# rdk/components/generic/netsrvmgr
+2b98d86af2b8302aac86b5a100000000
+# rdkb/components/opensource/ccsp/CcspEPONAgent
+2badc8bad94ca27b72658f3500000000
+# rdk/components/generic/hdmicec
+2d3a12d888cf706e1dd4055f00000000
+# rdkb/components/opensource/ccsp/GwProvApp-ePON
+2f2526bbea9588cd65a366ac00000000
+# rdkc/components/opensource/thumbnail
+30b7b366b3cf255c5f4cddb300000000
+# rdk/components/generic/bluetooth_mgr
+31249cee61fa8d2fc7eec43a00000000
+# rdk/components/generic/rmf_tools/generate_si_cache
+33f194c14bf4d6c247f7a53300000000
+# rdkb/devices/intel-x86-pc/emulator/tdkb
+34ad449236ecd330466b3ae600000000
+# rdk/components/generic/lxc-container-generator
+34e6f3c7cc4be127297b97c600000000
+# rdk/components/generic/rdk_logger
+361cae0c0c2ca825fb17cfcb00000000
+# rdkb/components/opensource/ccsp/MeshAgent
+38b2e06d92588f8886352c2100000000
+# rdk/components/opensource/oe/meta-linaro
+38c7c550fcdeeb42bbebb72200000000
+# rdk/components/generic/sys_mon_tools/iarm_query_powerstate
+39608218f6d4418aeb1b919a00000000
+# rdk/components/opensource/oe/meta-jz-mips
+398e9fecdebc6febf96067fb00000000
+# rdk/components/generic/dtcp
+39a2ceada87d6eedae95aa7900000000
+# rdk/components/generic/xconf-simulator
+39fe950c050612f5c01aca2600000000
+# rdkb/devices/intel-x86-pc/emulator/sysint
+3b95503d9e8099795d82974c00000000
+# components/opensource/v4l2test
+3bb97b8fd8862beaf1b6afd400000000
+# rdk/components/opensource/oe/meta-secure-core
+3ca020f5f8a2a4c5cf4fabd700000000
+# rdk/components/opensource/oe/meta-openembedded
+3df3fad0bf430978afa545f200000000
+# rdk/components/generic/sys_mon_tools/rdklogctrl
+42b54399191f591ed925966000000000
+# rdk/devices/intel-x86-pc/emulator/devicesettings
+45a3c381a9e33d5880b24f5500000000
+# rdk/components/generic/gst-plugins-rdk
+469f619259af5237a1dbc6e400000000
+# rdk/components/generic/cpuprocanalyzer
+4e0e609ae4840464d737e86d00000000
+# rdkb/components/opensource/ccsp/webui
+4eed51a55512542122f78b5700000000
+# rdkb/components/opensource/ccsp/RebootManager
+4f776ab8855ad0d19cc2ed6200000000
+# rdk/components/generic/audiocapturemgr
+509fc97ea60e6beb1c202d1700000000
+# rdk/devices/raspberrypi/tdk
+52bfe2a3b0018c6ff8657fc300000000
+# rdkc/devices/raspberrypi/mediastreamer
+54e8e5c02b6fe48cf3bcce9500000000
+# rdkb/components/opensource/ccsp/CcspXDNS
+56c293250ac98c4a671d5c8400000000
+# rdk/tools/tdk
+5789cfb05192f1da404bb81300000000
+# rdk/components/generic/ttsengine
+58178979ce4a4fbc542e746500000000
+# rdk/components/opensource/oe/meta-rtlwifi
+5a1ce6e65a20ab81b7c7846000000000
+# rdkb/components/opensource/ccsp/TestAndDiagnostic
+5aa5570bb6b4c520bac5a15900000000
+# rdkb/components/generic/harvester
+5c4e94b9bf9048928a4b357900000000
+# rdk/components/generic/gst-plugins-rdk-aamp
+5e2ab75fcf5f9b2b04690df600000000
+# rdk/devices/raspberrypi/iarmmgrs
+6071165faac2654711e1904700000000
+# components/opensource/rbus
+63e48edc1d3ea569e29ed97d00000000
+# rdk/components/generic/rdm
+64150612cd991af9806399d100000000
+# rdk/devices/intel-x86-pc/emulator/iarmmgrs
+659638e8e2cd732c9f63004a00000000
+# rdk/components/generic/dca
+6a0e0b06edcacca0d43a1fdf00000000
+# rdk/components/generic/wifi
+6a7e94c797b7284bc610853e00000000
+# rdkb/components/opensource/ccsp/FirmwareSanity
+6c971cb75c7444f4dbea71c100000000
+# rdkc/components/opensource/httpClients
+7112c0bb3cedb711a3b5333700000000
+# rdk/devices/intel-x86-pc/rdkemulator/gst-plugins-rdk/playersinkbin
+717b6c5feaee2a7f6ff5bcf800000000
+# rdk/components/generic/cobalt
+73042bcbe5fb5a5c2ed1da4c00000000
+# rdkb/components/opensource/ccsp/CcspPandM
+73ca93e95468a50d19dbeab400000000
+# rdkc/components/opensource/plugins
+76f1fb1f227750e7963e710200000000
+# rdk/components/generic/rdkmediaplayer
+774eca14e8f0602aecdb856800000000
+# rdk/components/generic/aamp
+7cb6e923b4c6d7351fe01a3200000000
+# rdkb/components/generic/servicemanager
+7e3fe2b6f2e960d15c4a67ce00000000
+# rdk/components/generic/hwselftest
+8160d7b856213b942f09767b00000000
+# rdk/components/generic/xupnp
+84912ff7c47c6a0afcb285cd00000000
+# components/opensource/RDK_apps
+86066d3e05d32169d321ec7100000000
+# rdkb/tools/tdkb
+86c8d7224e0aee9e5ae2fab300000000
+# rdk/components/opensource/oe/meta-browser
+86fa798256712121cafb76b700000000
+# rdk/components/generic/libusbctrl
+88faa82d3d6ac6beed9a538800000000
+# rdk/components/generic/devicesettings
+890bbc27ac4ffb9946e134db00000000
+# rdk/components/generic/rmf_tools/tenableHDCP
+8f437ef3a7cd7f955a168a3e00000000
+# rdk/components/generic/breakpad_wrapper
+8f55b8278f747c36b9d2ca7400000000
+# rdk/components/generic/rne
+95bb39e5d5b9d811220edf6a00000000
+# rdk/components/generic/rdkat
+96a5d7ec2c979a13d8b72dbd00000000
+# rdk/components/generic/netmonitor
+97bdfab69951cfed719754c100000000
+# components/opensource/westeros
+9a902bb420b74370487e484e00000000
+# rdkc/components/opensource/ledmgr
+9e99ceeb37255df11a4218c800000000
+# rdk/components/generic/tr69hostif
+9f81746b75f649527799b2ff00000000
+# rdkb/components/opensource/ccsp/CcspMoCA
+9f85b22d2ec2b4d5bd81ffcd00000000
+# rdk/devices/intel-x86-pc/rdkemulator/tdk
+a0b3b2a80052b106d28ce80f00000000
+# rdk/components/generic/bluetooth
+a173e2b6346a1d91c833aa2b00000000
+# rdk/components/generic/lxccpid
+a628c6479194b73a4a07e9aa00000000
+# components/opensource/waymetric
+a62940154adbd207e207095c00000000
+# rdkb/components/opensource/ccsp/CcspMtaAgent
+a823ca8d897038ec86955e5b00000000
+# rdk/components/generic/iarmbus
+aa674959b198ad8cf0107fe900000000
+# rdk/components/generic/sys_mon_tools/iarm_event_sender
+ab2cfd6f7f89471bdf83dce600000000
+# rdkb/components/generic/CcspLogAgent
+ac13c503dc5520179e26f48700000000
+# rdkcmf/meta-westeros-raspberrypi
+aea46ffc6d4435813f8a136a00000000
+# rdkc/devices/raspberrypi/tdkc
+af1efc6f5da8eb4f209a2ddc00000000
+# rdk/components/opensource/oe/meta-96boards
+b1782d92648d80b8e1f5e94000000000
+# rdk/components/generic/rdkbrowser
+b1c57310f9fec452fc79d18100000000
+# components/opensource/wayland-egl-icegdl
+b31ad1cfb0eb2f803a4be29400000000
+# rdkb/devices/raspberrypi/tdkb
+b4b8da1f296305731f110c9100000000
+# rdkb/components/opensource/ccsp/CcspWifiAgent
+b78a367b712de82f3aac137200000000
+# rdk/devices/raspberrypi/gst-plugins-rdk/playersinkbin
+b8c91803428899447b15c1fe00000000
+# rdk/devices/intel-x86-pc/rdkemulator/gst-plugins-rdk/qamtunersrc
+b8ccf187e446f7b5d5df1ca500000000
+# rdk/components/opensource/oe/meta-virtualization
+b96521bfbe8b6d6a9910a19e00000000
+# rdk/components/generic/appmanager
+ba0c86d5c01bdc06c35b3bca00000000
+# rdkb/components/opensource/ccsp/CcspWecbController
+bb48fda394fc8567dfa05fb300000000
+# rdk/components/generic/media_utils
+bc0a3725e8cb2d3ec3118ae200000000
+# rdk/components/generic/sys_mon_tools/si_cache_parser
+be2aaf5bc4afe45d0dd18d5f00000000
+# rdk/components/generic/libSyscallWrapper
+bf7c03cf5b3c7b98c1e2f1bc00000000
+# rdkc/tools/tdkc
+c438bbe2b9dc927e5cc7564c00000000
+# rdkb/components/opensource/ccsp/Utopia
+c56fc505f862dfa0dc8df6be00000000
+# rdk/components/opensource/oe/meta-wpe
+c6ae41fe3ecbb3fbda3374a300000000
+# rdk/components/generic/mocahal
+c7f7dd12c6c47f2d9e55e16600000000
+# rdkc/components/opensource/cvr
+cdf85cdb5fa13828d87a90c000000000
+# rdk/components/opensource/rtmessage
+cef528d6bc83c91b1c3caabf00000000
+# rdkc/components/opensource/rtmessage
+cefe9ea55ddf4627e5bb591d00000000
+# rdk/components/opensource/oe/openembedded-core
+cf30160dc190308e206f366c00000000
+# rdk/devices/raspberrypi/devicesettings
+cf86595dec6e144cda33f9d500000000
+# rdk/components/generic/diagnostics
+d55b46adb131c24b1b7a4b5100000000
+# rdkb/components/opensource/ccsp/sysint
+d5fbb2b67f2a3e8d4f3b33a900000000
+# rdkc/components/opensource/rms
+d60689cac6fcc8e19c3cf57c00000000
+# rdk/components/generic/injectedbundle
+d6b70a5ee62120bd82a10abf00000000
+# rdk/components/generic/crashupload
+d727ca07715b8fa358f900d200000000
+# rdk/components/generic/crashlog
+d83af57f9dd6160b159e701e00000000
+# rdk/components/generic/sys_mon_tools/sys_resource
+d92a5bbcda34a49236abdda600000000
+# rdkb/components/opensource/ccsp/servicemanager
+d97224a6f73eaa348c988e8200000000
+# rdkc/components/opensource/configMgr
+da8b4820e40bcf06eb491d1d00000000
+# rdkb/components/opensource/ccsp/utilities
+db5ebe3259f1b36b92818d1900000000
+# rdk/components/generic/xconfserver
+dc20f556a708560a6a6fb22900000000
+# rdk/components/generic/sys_mon_tools/iarm_set_powerstate
+e0d0efbe3414a31493d868fc00000000
+# rdk/components/generic/storagemanager
+e13473a724b0d15551da9dd600000000
+# rdk/components/generic/dcm
+e2a1022f74327ab18e8f37e300000000
+# rdk/components/generic/trm
+e77117e26a62ef760f39189e00000000
+# rdkb/components/opensource/ccsp/CcspSnmpPa
+e8b1d5c4a1825c7f55e9f6c500000000
+# rdkb/devices/ci20/hal
+eb10c85c56a36682e703af3a00000000
+# rdk/components/opensource/oe/meta-qt5
+f0f970a53288330a52f3780e00000000
+# components/opensource/rbuscore
+f365ae1c7af6543dda362eea00000000
+# rdk/components/generic/sys_mon_tools/mfr_utils
+f5f3093b9e7999c87cd0959c00000000
+# rdk/components/generic/rdkapps
+f71d6986f4de1e030225ad7000000000
+# rdkb/components/opensource/ccsp/GwProvApp
+f9230f364201a232d201797d00000000
+# devices/intel-x86-pc/rdkri/westeros
+fb0b012d7d6c836bb0be772600000000
+# rdk/components/generic/rfc
+fc15a7b0c7b974c0913a795200000000
+# rdkb/components/opensource/ccsp/hal
+fc6593467d7da7131712575300000000
+# rdkb/components/opensource/ccsp/CcspEthAgent
+fe4b531e392af92e932231d300000000


### PR DESCRIPTION
This pull request updates the FossID integration workflow to use the newer `fossid-toolbox` for diff scanning and introduces a centralized ignore list for projects to be excluded from scans. The changes modernize the workflow, improve maintainability, and provide better control over what gets scanned.

**Workflow modernization and tool update:**

- The GitHub Actions workflow in `.github/workflows/fossid_integration_stateless_diffscan.yml` now uses the `fossid-toolbox:1.5.29` container image instead of the older `fossid-cicd:0.2.15`, and updates the job name and step names for clarity. The scanning command is updated from `fossid-cicd diff-scan` to `fossid diffscan` with new flags for improved output and error handling.

**Centralized ignore configuration:**

- Adds a new `ignore_projects_fossid` file containing a comprehensive list of project paths and identifiers to be excluded from FossID scans. This file is checked out from the `build_tools_workflows` repository during the workflow run and referenced in the scan command, ensuring a consistent and maintainable way to manage ignored projects.

**Improvements to repository and step management:**

- The workflow now checks out both the main code and the tools repository (for the ignore list) using `actions/checkout@v5`, and uses sparse checkout to fetch only the necessary ignore file, reducing unnecessary data transfer and setup time.