### PR TITLE
Add issues:write to PR Format Check job permissions

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -9,6 +9,8 @@ jobs:
   pr-lint:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+      issues: write
       pull-requests: write
     steps:
       - name: Check PR Title & Description Format


### PR DESCRIPTION
## Summary
Adds `issues: write` and explicit `contents: read` to the `pr-lint` job permissions in the shared PR Format Check workflow.

## Why
PR conversation comments are created/updated/deleted via the **Issues API** (`/repos/{o}/{r}/issues/comments`). To be robust, the job needs `issues: write` in addition to `pull-requests: write`. This resolves a reviewer concern that `pull-requests: write` alone may be insufficient for the comment operations.

Least-privilege final set:
```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

## Files changed
- `.github/workflows/pr-lint.yml`