### PR TITLE
RDKB-66032 : Fix PR title regex to allow digits in Jira project keys

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -32,7 +32,7 @@ jobs:
           # ==========================================
           # 1. TITLE: TICKET-123 [TICKET-456] : description
           # ==========================================
-          if ! echo "$PR_TITLE" | grep -qE '^[A-Z]+-[0-9]+( [A-Z]+-[0-9]+)* *: *[^[:space:]]+'; then
+          if ! echo "$PR_TITLE" | grep -qE '^[A-Z][A-Z0-9]+-[0-9]+( [A-Z][A-Z0-9]+-[0-9]+)* *: *[^[:space:]]+'; then
             ISSUES+="- **Title:** \`${SAFE_TITLE}\` — expected \`TICKET-123 : description\`\n"
             ISSUES+="  _(Multiple tickets OK: \`RDKCOM-5492 RDKBDEV-3336 : ...\`  |  Include US ticket + subtask for user-stories)_\n"
           fi

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -30,7 +30,7 @@ jobs:
           SAFE_TITLE=$(echo "$PR_TITLE" | sed "s/\`/'/g")
 
           # ==========================================
-          # 1. TITLE: TICKET-123 [TICKET-456] : description
+          # 1. TITLE: TICKET-123 : description   (multiple tickets allowed, space-separated, e.g. "TICKET-123 TICKET-456 : description")
           # ==========================================
           if ! echo "$PR_TITLE" | grep -qE '^[A-Z][A-Z0-9]+-[0-9]+( [A-Z][A-Z0-9]+-[0-9]+)* *: *[^[:space:]]+'; then
             ISSUES+="- **Title:** \`${SAFE_TITLE}\` — expected \`TICKET-123 : description\`\n"


### PR DESCRIPTION
Fixes the PR Format Check title validation to accept Jira project keys with digits (e.g. XB10, XB7, TCHXB7).

Changed project-key pattern from `[A-Z]+` to `[A-Z][A-Z0-9]+`.

Real example: rdkcentral/utopia#374  was wrongly flagged as failing.
